### PR TITLE
Add functions of removeCachedEvent

### DIFF
--- a/RxController/Classes/RxViewModel.swift
+++ b/RxController/Classes/RxViewModel.swift
@@ -98,6 +98,22 @@ open class RxViewModel: NSObject, Stepper {
         return events
     }
     
+    public func removeCachedEvent(at eventIdentifier: RxControllerEvent.Identifier) {
+        let cachedEventIds = cachedEvents.map { $0.identifier.id }
+        if let index = cachedEventIds.firstIndex(of: eventIdentifier.id) {
+            cachedEvents.remove(at: index)
+        }
+    }
+    
+    public func removeCachedEvents(_ eventIdentifiers: [RxControllerEvent.Identifier]) {
+        eventIdentifiers.forEach {
+            removeCachedEvent(at: $0)
+        }
+    }
+    
+    public func removeAllCachedEvents() {
+        cachedEvents.removeAll()
+    }
 }
 
 extension RxViewModel: RxControllerEventBinder {}


### PR DESCRIPTION
When a cachedEvent is resent by performing addChild, the same event as the parent sees events is picked up twice, so prepare a means to clear the Cache.