### PR TITLE
Add Cachable to RxControllerEvent

### DIFF
--- a/RxController/Classes/RxControllerEvent.swift
+++ b/RxController/Classes/RxControllerEvent.swift
@@ -31,27 +31,30 @@ public struct RxControllerEvent {
     
     public struct Identifier {
         var id: String
+        var cacheable: Bool
         
-        static let none = Identifier(id: "none")
+        static let none = Identifier(id: "none", cacheable: false)
         
         public func event(_ value: Any?) -> RxControllerEvent {
-            return RxControllerEvent(identifier: self, value: value)
+            return RxControllerEvent(identifier: self, value: value, cacheable: cacheable)
         }
     }
     
     var identifier: Identifier
     var value: Any?
+    var cacheable: Bool
     
-    init(identifier: Identifier, value: Any?) {
+    init(identifier: Identifier, value: Any?, cacheable: Bool) {
         self.identifier = identifier
         self.value = value
+        self.cacheable = cacheable
     }
 
-    static let none = RxControllerEvent(identifier: .none, value: nil)
-    static let steps = RxControllerEvent.identifier()
+    static let none = RxControllerEvent(identifier: .none, value: nil, cacheable: false)
+    static let steps = RxControllerEvent.identifier(cacheable: false)
     
-    public static func identifier() -> Identifier {
-        return Identifier(id: UUID().uuidString)
+    public static func identifier(cacheable: Bool = true) -> Identifier {
+        return Identifier(id: UUID().uuidString, cacheable: cacheable)
     }
     
 }

--- a/RxController/Classes/RxViewModel.swift
+++ b/RxController/Classes/RxViewModel.swift
@@ -39,6 +39,7 @@ open class RxViewModel: NSObject, Stepper {
         super.init()
         
         events.subscribe(onNext: { [unowned self] in
+            guard $0.cacheable else { return }
             guard $0.identifier.id != RxControllerEvent.steps.id else { return }
             let cachedEventIds = self.cachedEvents.map { $0.identifier.id }
             if let index = cachedEventIds.firstIndex(of: $0.identifier.id) {


### PR DESCRIPTION
## Purpose
Events that are cached during addChild run, but some events you want to ignore.
Therefore, you can choose not to cache RxControllerEvent.

## Excuse
It's weird that the identifier has a cacheable flag, but prioritized not to affect existing code.

## use

```swfit
enum HogeEvent {
    static let hoge = RxControllerEvent.identifier()
    static let didTapFuga = RxControllerEvent.identifier(cachable: false)
}
```